### PR TITLE
Add rootState to module action's example code

### DIFF
--- a/docs/en/modules.md
+++ b/docs/en/modules.md
@@ -57,8 +57,8 @@ Similarly, inside module actions, `context.state` will expose the local state, a
 const moduleA = {
   // ...
   actions: {
-    incrementIfOdd ({ state, commit }) {
-      if (state.count % 2 === 1) {
+    incrementIfOddOnRootSum ({ state, commit, rootState }) {
+      if (state.count + rootState.count % 2 === 1) {
         commit('increment')
       }
     }


### PR DESCRIPTION
The description of module action:
> Similarly, inside module actions, `context.state` will expose the local state, and root state will be exposed as `context.rootState`:

However `context.rootState` does not appear in the original example code, which might confuse some readers. The proposed change appends `rootState` to the argument list and make use of it in the action.

/cc @yyx990803